### PR TITLE
Potential fix for code scanning alert Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -14,7 +14,7 @@ on:
             - '**/*.css'
             - '**/*.scss'
             - '**/*.html'
-            - '.github/workflows/code-qa.yml'
+            - '.github/workflows/code-qa.yaml'
     pull_request:
         branches: [main]
         paths:
@@ -28,7 +28,7 @@ on:
             - '**/*.css'
             - '**/*.scss'
             - '**/*.html'
-            - '.github/workflows/code-qa.yml'
+            - '.github/workflows/code-qa.yaml'
 
 permissions:
     contents: read

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -7,14 +7,14 @@ on:
             - '**/*.md'
             - '.markdownlint.json'
             - '.markdownlintignore'
-            - '.github/workflows/markdown-lint.yml'
+            - '.github/workflows/markdown-lint.yaml'
     pull_request:
         branches: [main]
         paths:
             - '**/*.md'
             - '.markdownlint.json'
             - '.markdownlintignore'
-            - '.github/workflows/markdown-lint.yml'
+            - '.github/workflows/markdown-lint.yaml'
 
 permissions:
     contents: read


### PR DESCRIPTION
Fix for "Workflow does not contain permissions" by adding `permissions: contents: read`.